### PR TITLE
Allow Terraform 1.0.x to use this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Terraform](https://www.terraform.io) base module for deploying and managing
 [IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) on
 [Amazon Web Services (AWS)](https://aws.amazon.com/).
 
-**_This module supports Terraform v0.15, v0.14, v0.13, as well as v0.12.20 and above
+**_This module supports Terraform v1.0, v0.15, v0.14, v0.13, as well as v0.12.20 and above
 and is compatible with the terraform AWS provider v3 as well as v2.0 and above._**
 
 - [Module Features](#module-features)

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20, ~> 1.0.0"
+  required_version = ">= 0.12.20, < 1.1.0"
 
   required_providers {
     aws = ">= 2.0, < 4.0"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20, < 0.16"
+  required_version = ">= 0.12.20, ~> 1.0.0"
 
   required_providers {
     aws = ">= 2.0, < 4.0"


### PR DESCRIPTION
Hey, needed to run this on 1.0.2 and it worked fine. PR to change `versions.tf` to allow any terraform 1.0.x to use this module.