### PR TITLE
Terraform v1 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+
+- Add support for Terraform `v1`
+
 ## [0.4.0]
 
 ### Added
@@ -62,11 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 
-[unreleased]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.2.0...v0.4.0
+[unreleased]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.4.0...v0.5.0
 
 <!-- markdown-link-check-disabled -->
 
+[0.4.0]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.2.0...v0.4.0
 [0.2.0]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mineiros-io/terraform-aws-iam-policy/compare/v0.0.2...v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Set default shell to bash
 SHELL := /bin/bash -o pipefail
 
-BUILD_TOOLS_VERSION      ?= v0.11.0
+BUILD_TOOLS_VERSION      ?= v0.12.1
 BUILD_TOOLS_DOCKER_REPO  ?= mineiros/build-tools
 BUILD_TOOLS_DOCKER_IMAGE ?= ${BUILD_TOOLS_DOCKER_REPO}:${BUILD_TOOLS_VERSION}
 
@@ -32,29 +32,32 @@ endif
 
 GIT_TOPLEVEl = $(shell git rev-parse --show-toplevel)
 
-# generic docker run flags
+# Generic docker run flags
 DOCKER_RUN_FLAGS += -v ${GIT_TOPLEVEl}:/build
 DOCKER_RUN_FLAGS += --rm
 DOCKER_RUN_FLAGS += -e TF_IN_AUTOMATION
 
-# if SSH_AUTH_SOCK is defined we are likely referencing private repositories
-# for depending terrfaorm modules or other depdendencies
-# so we pass credentials to the docker container when running tests or pre-commit hooks
+# If SSH_AUTH_SOCK is set, we forward the SSH agent of the host system into
+# the docker container. This is useful when working with private repositories
+# and dependencies that might need to be cloned inside the container (e.g.
+# private Terraform modules).
 ifdef SSH_AUTH_SOCK
   DOCKER_SSH_FLAGS += -e SSH_AUTH_SOCK=/ssh-agent
   DOCKER_SSH_FLAGS += -v ${SSH_AUTH_SOCK}:/ssh-agent
 endif
 
-# if AWS_ACCESS_KEY_ID is defined we are likely running inside an AWS provider module
-# so we pass credentials to the docker container when running tests
+# If AWS_ACCESS_KEY_ID is defined, we are likely running inside an AWS provider
+# module. To enable AWS authentication inside the docker container, we inject
+# the relevant environment variables.
 ifdef AWS_ACCESS_KEY_ID
   DOCKER_AWS_FLAGS += -e AWS_ACCESS_KEY_ID
   DOCKER_AWS_FLAGS += -e AWS_SECRET_ACCESS_KEY
   DOCKER_AWS_FLAGS += -e AWS_SESSION_TOKEN
 endif
 
-# if GITHUB_OWNER is defined we are running inside a github provider module
-# so we pass credentials to the docker container when running tests
+# If GITHUB_OWNER is defined, we are likely running inside a GitHub provider
+# module. To enable GitHub authentication inside the docker container,
+# we inject the relevant environment variables.
 ifdef GITHUB_OWNER
   DOCKER_GITHUB_FLAGS += -e GITHUB_TOKEN
   DOCKER_GITHUB_FLAGS += -e GITHUB_OWNER
@@ -80,6 +83,7 @@ test/pre-commit:
 test/unit-tests: DOCKER_FLAGS += ${DOCKER_SSH_FLAGS}
 test/unit-tests: DOCKER_FLAGS += ${DOCKER_GITHUB_FLAGS}
 test/unit-tests: DOCKER_FLAGS += ${DOCKER_AWS_FLAGS}
+test/unit-tests: DOCKER_FLAGS += -e TF_DATA_DIR=.terratest
 test/unit-tests: TEST ?= "TestUnit"
 test/unit-tests:
 	@echo "${YELLOW}[TEST] ${GREEN}Start Running Go Tests in Docker Container.${RESET}"
@@ -108,7 +112,7 @@ help:
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 
-# define helper functions
+# Define helper functions
 DOCKER_FLAGS   += ${DOCKER_RUN_FLAGS}
 DOCKER_RUN_CMD  = docker run ${DOCKER_FLAGS} ${BUILD_TOOLS_DOCKER_IMAGE}
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Terraform](https://www.terraform.io) base module for deploying and managing
 [IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) on
 [Amazon Web Services (AWS)](https://aws.amazon.com/).
 
-**_This module supports Terraform v1.0, v0.15, v0.14, v0.13, as well as v0.12.20 and above
+**_This module supports Terraform v1.x, v0.15, v0.14, v0.13, as well as v0.12.20 and above
 and is compatible with the terraform AWS provider v3 as well as v2.0 and above._**
 
 - [Module Features](#module-features)
@@ -250,7 +250,7 @@ Copyright &copy; 2020-2021 [Mineiros GmbH][homepage]
 [badge-build]: https://github.com/mineiros-io/terraform-aws-iam-policy/workflows/Tests/badge.svg
 [badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-aws-iam-policy.svg?label=latest&sort=semver
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
-[badge-terraform]: https://img.shields.io/badge/terraform-0.15%20|%200.14%20|%200.13%20|%200.12.20+-623CE4.svg?logo=terraform
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|%200.14%20|%200.13%20and%200.12.20+-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [badge-tf-aws]: https://img.shields.io/badge/AWS-3%20and%202.0+-F8991D.svg?logo=terraform
 [releases-aws-provider]: https://github.com/terraform-providers/terraform-provider-aws/releases

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,22 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/e9fff6ecb9617dcb405079f301e23fd83b79c5f3/mineiros-primary-logo.svg" width="400"/>](https://mineiros.io/?ref=terraform-aws-iam-policy)
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
 
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/terraform-aws-iam-policy.svg?label=latest&sort=semver)](https://github.com/mineiros-io/terraform-aws-iam-policy/releases)
-[![license](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Terraform Version](https://img.shields.io/badge/terraform-~%3E%200.12.20-623CE4.svg)](https://github.com/hashicorp/terraform/releases)
-[<img src="https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack">](https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg)
+[![GitHub tag (latest SemVer)][badge-semver]][releases-github]
+[![license][badge-license]][apache20]
+[![Terraform Version][badge-terraform]][releases-terraform]
+[![Join Slack][badge-slack]][slack]
 
 # Examples for using the Mineiros IAM Policy Module
 
 - [iam-policy-s3-full-access/](https://github.com/mineiros-io/terraform-aws-iam-policy/blob/master/examples/iam-policy-s3-full-access)
 Create an IAM Policy that grants full access to S3.
+
+<!-- References -->
+[homepage]: https://mineiros.io/?ref=terraform-aws-iam-policy
+[badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|%200.14%20|%200.13%20and%200.12.20+-623CE4.svg?logo=terraform
+[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
+[badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-aws-iam-policy.svg?label=latest&sort=semver
+[releases-github]: https://github.com/mineiros-io/terraform-aws-iam-policy/releases
+[releases-terraform]: https://github.com/hashicorp/terraform/releases
+[apache20]: https://opensource.org/licenses/Apache-2.0
+[slack]: https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg

--- a/examples/iam-policy-s3-full-access/README.md
+++ b/examples/iam-policy-s3-full-access/README.md
@@ -188,7 +188,7 @@ Copyright &copy; 2020 Mineiros GmbH
 [hello@mineiros.io]: mailto:hello@mineiros.io
 [badge-build]: https://mineiros.semaphoreci.com/badges/terraform-aws-iam-policy/branches/master.svg?style=shields
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
-[badge-terraform]: https://img.shields.io/badge/terraform-0.13%20and%200.12.20+-623CE4.svg?logo=terraform
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|%200.14%20|%200.13%20and%200.12.20+-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [build-status]: https://mineiros.semaphoreci.com/projects/terraform-aws-iam-policy
 [releases-github]: https://github.com/mineiros-io/terraform-aws-iam-policy/releases

--- a/test/README.md
+++ b/test/README.md
@@ -72,7 +72,7 @@ Alternatively, you can also run the tests without Docker.
 [Go]: https://golang.org/
 [Terraform]: https://www.terraform.io/downloads.html
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
-[badge-terraform]: https://img.shields.io/badge/terraform-0.13%20and%200.12.20+-623CE4.svg?logo=terraform
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|%200.14%20|%200.13%20and%200.12.20+-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 
 [releases-terraform]: https://github.com/hashicorp/terraform/releases

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20, < 1.1.0"
+  required_version = ">= 0.12.20, < 2.0"
 
   required_providers {
     aws = ">= 2.0, < 4.0"


### PR DESCRIPTION
- build: upgrade build-tools to v0.12.1
- feat: add compatibility for Terraform v1
- docs: update docs to include Terraform v1
- chore: prepare v0.5.0 release
